### PR TITLE
Cancel feature before joining discussion from self-reflection

### DIFF
--- a/src/ui/components/video/VideoDiscussion.js
+++ b/src/ui/components/video/VideoDiscussion.js
@@ -169,6 +169,9 @@ function VideoComponent(props) {
   // fetch raw pin data here
   const { pins } = usePinsValue();
 
+  // Originally "readyToJoin"
+  // Now skipping the dialog box, directly begin the discussion
+  // useEffect below will call this function directly as the entry point
   const readyToJoin = () => {
     pins.forEach((elem, id) => savePin(id));
     handleStartChat(setApiKey, setVonageSessionID, setToken, baseURL);
@@ -622,31 +625,16 @@ How did today’s mock client session go?
     );
   };
 
+  // Will directly render the video call page
+  // Dialog box in the return has been removed
+  useEffect(() => {
+    // Function to be called once
+    readyToJoin();
+  }, []); // Empty dependency array ensures the effect is executed only once
+
   return (
     <>
       <Box pt={10}>{loadingStatus ? <LinearProgress /> : null}</Box>
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
-      >
-        <DialogTitle id="alert-dialog-title">{'Are you sure you want to join the discussion?'}</DialogTitle>
-        <DialogActions>
-          <Box m={2}>
-            <div direction="row" align="center">
-              {/* <ColorLibButton variant="contained" size="medium" onClick={() => setOpen(false)} autoFocus>
-                Add more notes to pins
-              </ColorLibButton> */}
-              {/* <Box mt={2}> */}
-              <ColorLibButton variant="contained" size="medium" onClick={readyToJoin} autoFocus>
-                Join Discussion
-              </ColorLibButton>
-              {/* </Box> */}
-            </div>
-          </Box>
-        </DialogActions>
-      </Dialog>
       {videoBox(props.mode === 'Discussion' ? 'mini' : 'full')}
     </>
   );

--- a/src/ui/pages/discussionPrep/DisscussionPrep.jsx
+++ b/src/ui/pages/discussionPrep/DisscussionPrep.jsx
@@ -10,7 +10,7 @@ import Transcription from '../../components/transcript/Transcription';
 import { makeStyles } from '@material-ui/core/styles';
 import { Container, Grid, Typography } from '@material-ui/core';
 
-import ColorLibButton from '../../components/colorLibComponents/ColorLibButton';
+import ColorLibButton, { ColorLibNextButton } from '../../components/colorLibComponents/ColorLibButton';
 import { useActiveStepValue, usePinsValue } from '../../../storage/context';
 import { firebase } from '../../../storage/firebase';
 import { useSelector, useDispatch } from 'react-redux';
@@ -20,6 +20,8 @@ import ColorLibTimeReminder from '../../components/colorLibComponents/ColorLibTi
 
 import { formatTime } from '../../../helper/helper';
 import { baseURL } from '../../pages/misc/constants';
+
+import { Dialog, Box, DialogTitle, DialogActions } from '@material-ui/core';
 
 // socket.io
 // const socket = io.connect(baseURL);
@@ -100,6 +102,12 @@ const DisscussionPrep = () => {
   const recommendedTime = 10 * 60;
   const [countDown, setCountDown] = useState(recommendedTime);
   const [timeRemind, setTimeRemind] = useState(false);
+
+  // Join Discussion dialog
+  const [openJoin, setOpenJoin] = useState(false);
+  const handleClose = () => {
+    setOpenJoin(false);
+  };
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -278,9 +286,40 @@ const DisscussionPrep = () => {
         </Grid>
       </Container>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '20px 0 50px 0' }}>
-        <ColorLibButton variant="contained" size="medium" onClick={handleJoinDiscussion}>
+        <ColorLibButton variant="contained" size="medium" onClick={() => setOpenJoin(true)}>
           {session.recordOnly ? 'End Session' : 'Join Discussion'}
         </ColorLibButton>
+      </div>
+      <div>
+        <Dialog
+          open={openJoin}
+          onClose={handleClose}
+          aria-labelledby="alert-dialog-title"
+          aria-describedby="alert-dialog-description"
+        >
+          <DialogTitle id="alert-dialog-title">
+            {'Are you sure you want to'}
+            {session.recordOnly ? 'end the session?' : 'join the discussion?'}
+          </DialogTitle>
+          <DialogActions>
+            <Box m={4}>
+              <div
+                // direction="row" align="center"
+                style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+              >
+                <ColorLibButton variant="outlined" size="medium" onClick={() => setOpenJoin(false)} autoFocus>
+                  {/* Stay in Discussion Prep */}
+                  Cancel
+                </ColorLibButton>
+                &nbsp; &nbsp; &nbsp; &nbsp;
+                <ColorLibNextButton variant="contained" size="medium" onClick={() => handleJoinDiscussion()} autoFocus>
+                  {/* Begin peer-feedback discussion */}
+                  Join Discussion
+                </ColorLibNextButton>
+              </div>
+            </Box>
+          </DialogActions>
+        </Dialog>
       </div>
     </div>
   );

--- a/src/ui/pages/discussionPrep/DisscussionPrep.jsx
+++ b/src/ui/pages/discussionPrep/DisscussionPrep.jsx
@@ -298,7 +298,7 @@ const DisscussionPrep = () => {
           aria-describedby="alert-dialog-description"
         >
           <DialogTitle id="alert-dialog-title">
-            {'Are you sure you want to'}
+            {'Are you sure you want to '}
             {session.recordOnly ? 'end the session?' : 'join the discussion?'}
           </DialogTitle>
           <DialogActions>


### PR DESCRIPTION
This enhances the original "Are you sure to join the discussion" dialog. When finished self-reflection, a new dialog will prompt with both cancel and join. Users can go back to the reflection page if they do not want to go join the discussion.

<img width="1038" alt="image" src="https://github.com/CoExLab/pinmi/assets/68986725/77a014dc-781f-4935-a429-ed250094c63e">
