### PR TITLE
[WIP] Remove two redundant pages in Discussion of the Pins

### DIFF
--- a/src/ui/pages/discussion/Discussion.jsx
+++ b/src/ui/pages/discussion/Discussion.jsx
@@ -48,7 +48,9 @@ const Discussion = () => {
   const classes = useStyles();
 
   //current page in the Discussion section
-  const [page, setPage] = useState(0);
+  // this was changed from 0 to 1, because there's no need to display
+  // the 0 and 2 page
+  const [page, setPage] = useState(1);
 
   //session and user information taken from Redux
   const session = useSelector(state => state.session);
@@ -210,11 +212,13 @@ const Discussion = () => {
       //next section is accessed
       setEndVideo(true);
     } else {
-      if (page === 0) {
-        //pull pin updates from previous section and from both users
-        //loadPins automatically moves to the next page after completion
-        loadPins();
-      } else if (page === 1) {
+      // if (page === 0) {
+      //   //pull pin updates from previous section and from both users
+      //   //loadPins automatically moves to the next page after completion
+      //   loadPins();
+      // } else
+      // The above case is removed because there will no longer be page 0
+      if (page === 1) {
         //pin indices are reset to force the last pin to save
         setPrevPinIndex(curPinIndex);
         if (curPinIndex === 0) {
@@ -250,7 +254,10 @@ const Discussion = () => {
         pins.sort((a, b) => a.pinTime - b.pinTime);
       })
       .then(() => {
-        setPage(page + 1);
+        // setPage(page + 1);
+        // no longer needs to increment the page number, as the page will start
+        // from 1
+        // when calling loadPins, the page is already at 1
       })
       .catch(err => console.error('Error in loadPins functions: ', err));
   };
@@ -259,18 +266,18 @@ const Discussion = () => {
   //page must be a valid integer between 0 and 2
   function getConditionalButton(page) {
     switch (page) {
-      case 0:
-        return (
-          <Box className={classes.videoButton}>
-            <ColorLibPaper elevation={2} className={classes.description}>
-              <Typography variant="body2">Introduce yourself to your peer, who is also learning MI.</Typography>
-              <Typography variant="body2">How did today’s mock client session go?</Typography>
-            </ColorLibPaper>
-            <ColorLibGrayNextButton variant="contained" size="medium" onClick={() => handleButton(false)}>
-              Let's talk about our pins
-            </ColorLibGrayNextButton>
-          </Box>
-        );
+      // case 0:
+      //   return (
+      //     <Box className={classes.videoButton}>
+      //       <ColorLibPaper elevation={2} className={classes.description}>
+      //         <Typography variant="body2">Introduce yourself to your peer, who is also learning MI.</Typography>
+      //         <Typography variant="body2">How did today’s mock client session go?</Typography>
+      //       </ColorLibPaper>
+      //       <ColorLibGrayNextButton variant="contained" size="medium" onClick={() => handleButton(false)}>
+      //         Let's talk about our pins
+      //       </ColorLibGrayNextButton>
+      //     </Box>
+      //   );
       case 1:
         return (
           <Box align="center" m={2} mb={20}>
@@ -296,6 +303,12 @@ const Discussion = () => {
         return <div>Unknown</div>;
     }
   }
+
+  useEffect(() => {
+    // Function to be called once
+    // directly load the pins to skip page 0
+    loadPins();
+  }, []); // Empty dependency array ensures the effect is executed only once
 
   //actual rendering
   return (


### PR DESCRIPTION
This is a Work in Progress~

This PR will remove two pages when the users are about to enter the discussion. Before the changes, the users will do the following when joining the Pin discussion after self-reflecting on the Pins: Intro -> Pins Page -> Epilogue. This PR will remove the Intro and Epilogue. The users will be brought directly to the Pins page with the video call open on the side.

Major tasks:
- [x] Remove the intro page
- [ ] Remove the epilogue page (end the call directly after the pins discussion)
- [ ] Bring the "End Call" button to the Pins Page
- [ ] Prompt the user to make sure to end the call on the Pins Page

Known bug:
- [ ] Noticed that sometimes, the video call cannot be joined directly and will be a blank screen in the draft deployment site. need to replicate in local environment and fix.
- [ ] In local environment, when there are two users in the session, a bug will occur. If there's only one single user, the video call can proceed as usual. this should very much linked to the issue above.

Nice things to have to improve the design:
- Prompt the user when they are about to join the video discussion after self-reflection. I'm thinking this to be a similar dialog box when the video call first starts (prompt the users to check their video, and microphone, and choose whether to turn them on or off). However, not really sure if the video call is restarted or resumed because the microphone and camera seem to always be on during self-reflection. 
- Simplify the code in src/ui/pages/discussion/Discussion.jsx as many code will no longer be used
- 



