### PR TITLE
End call notification

### DIFF
--- a/src/ui/components/video/VideoChatComponent.js
+++ b/src/ui/components/video/VideoChatComponent.js
@@ -559,6 +559,11 @@ function VideoChatComponent(props) {
       .catch(error => {
         console.log(error);
       });
+
+    // Set a new field in the firebase to signal that the call is ongoing
+    await firebase.firestore().collection('sessions').doc(session.sessionID).update({
+      oneUserEnded: false,
+    });
   };
 
   const handleFinishChat = async () => {
@@ -621,6 +626,10 @@ function VideoChatComponent(props) {
     if (pins[0]) {
       console.log(pins[0]);
     }
+    // Call has ended, update in the firebase
+    await firebase.firestore().collection('sessions').doc(session.sessionID).update({
+      oneUserEnded: true,
+    });
   };
 
   const handleStartArchive = async () => {

--- a/src/ui/components/video/VideoChatComponent.js
+++ b/src/ui/components/video/VideoChatComponent.js
@@ -655,6 +655,12 @@ function VideoChatComponent(props) {
     await firebase.firestore().collection('sessions').doc(session.sessionID).update({
       oneUserEnded: true,
     });
+
+    // Indicate that the reflection has started before leaving the call
+    // the following is to be used in DisscussionPrep file
+    await firebase.firestore().collection('sessions').doc(session.sessionID).update({
+      oneUserReflectEnded: false,
+    });
   };
 
   const handleStartArchive = async () => {

--- a/src/ui/components/video/VideoChatComponent.js
+++ b/src/ui/components/video/VideoChatComponent.js
@@ -106,6 +106,10 @@ function VideoChatComponent(props) {
   const [buttonDis, setButtonDis] = useState(false);
   const [buttonDisStop, setButtonDisStop] = useState(true);
 
+  // true if the user has been notified that the other user ended the call
+  const [notifiedEnding, setNotifiedEnding] = useState(false);
+  const [notifyBox, setNotifyBox] = useState(false);
+
   const recommendedTime = 10 * 60;
   const [countDown, setCountDown] = useState(recommendedTime); // 10 minutes
 
@@ -544,10 +548,9 @@ function VideoChatComponent(props) {
       .onSnapshot(snapshot => {
         // Code here will be performed once the database has an update
         // Perform notice only when other has ended the call and user is calling
-        if (snapshot.data().oneUserEnded) {
-          console.log(
-            'THE OTHER USER HAS ENDED THE CALL THE OTHER USER HAS ENDED THE CALL THE OTHER USER HAS ENDED THE CALL',
-          );
+        if (snapshot.data().oneUserEnded && !notifiedEnding) {
+          setNotifiedEnding(true);
+          setNotifyBox(true);
         }
       });
     await fetch(baseURL + 'room/' + room + roomAddOn)
@@ -873,6 +876,37 @@ function VideoChatComponent(props) {
                 {/* Begin self-reflection */}
                 Confirm
               </ColorLibNextButton>
+            </div>
+          </Box>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={notifyBox}
+        onClose={() => setNotifyBox(false)}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">{'Your partner has ended the call.'}</DialogTitle>
+        <DialogActions>
+          <Box m={4}>
+            <div
+              // direction="row" align="center"
+              style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+            >
+              <ColorLibButton variant="outlined" size="medium" onClick={() => setNotifyBox(false)} autoFocus>
+                {/* Stay in role-play */}
+                OK
+              </ColorLibButton>
+              &nbsp; &nbsp; &nbsp; &nbsp;
+              <ColorLibCallEndButton
+                variant="contained"
+                size="medium"
+                onClick={() => handleFinishChat()}
+                disabled={!isInterviewStarted}
+              >
+                {session.recordOnly ? 'End Session' : 'Begin Self-reflection'}
+              </ColorLibCallEndButton>
             </div>
           </Box>
         </DialogActions>

--- a/src/ui/components/video/VideoChatComponent.js
+++ b/src/ui/components/video/VideoChatComponent.js
@@ -887,7 +887,7 @@ function VideoChatComponent(props) {
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
       >
-        <DialogTitle id="alert-dialog-title">{'Your partner has ended the call.'}</DialogTitle>
+        <DialogTitle id="alert-dialog-title">{'Your partner has ended the call'}</DialogTitle>
         <DialogActions>
           <Box m={4}>
             <div


### PR DESCRIPTION
Notify users if their partner has ended the call. A new dialog box will prompt the user to end the call when their partner has ended it.

A new field has been added to the Firebase Database, named "oneUserEnded". The users will listen to the Firebase changes and respond when this field changes. The relevant information has been added to the Documentation folder.

A similar feature is added to the reflection page with a corresponding field called "oneUserReflectEnded". The user will be notified if the other user has ended the reflection and is ready to join the discussion.

Potentially, the Discussion page can also use this feature but this will be paused until redundant pages are removed, and because the Discussion doesn't really benefit a lot from this feature.



<img width="1389" alt="image" src="https://github.com/CoExLab/pinmi/assets/68986725/3445c464-bd3e-4d77-acb3-f12014eacb91">

<img width="1774" alt="image" src="https://github.com/CoExLab/pinmi/assets/68986725/3c6d3654-da16-4a1a-91bf-afb7124cb2ff">
